### PR TITLE
add support for LinuxMint operating system

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,7 +9,7 @@ This module installs vagrant and, optionally, vagrant boxes and plugins.
 Works on all the platforms supported by vagrant:
 
 - Centos/Red Hat
-- Debian/Ubuntu
+- Debian/Ubuntu/LinuxMint
 - Mac OS X
 - Windows
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class vagrant($version = get_latest_vagrant_version()) {
       $vagrant_source   = "${base_url}/${darwin_prefix}${version}.dmg"
       $vagrant_provider = 'pkgdmg'
     }
-    debian, ubuntu: {
+    debian, ubuntu, linuxmint: {
       case $::architecture {
         x86_64, amd64: {
           $vagrant_filename = "vagrant_${version}_x86_64.deb"

--- a/spec/classes/vagrant_spec.rb
+++ b/spec/classes/vagrant_spec.rb
@@ -46,7 +46,7 @@ describe 'vagrant' do
     end
   end
   context 'deb' do
-    ['debian', 'ubuntu'].each do |distro|
+    ['debian', 'ubuntu', 'linuxmint'].each do |distro|
       context 'x64' do
         ['x86_64', 'amd64'].each do |arch|
           let(:facts) { { :architecture => arch, :operatingsystem => distro, :ostempdir => '/tmp' } }


### PR DESCRIPTION
Since [facter 2.1.0](https://docs.puppetlabs.com/facter/2.1/release_notes.html), [LinuxMint is now supported](https://docs.puppetlabs.com/facter/2.1/release_notes.html#improvements-to-operating-system-detection) by the `operatingsystem` and `osfamily` facts. Thus the os detection stuff needs to be updated.
