### PR TITLE
Install plugins with specified version.

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -11,10 +11,23 @@
 #   The user under which the plugin will be added. Ignored on Windows
 #   systems (current user is assumed).
 #
-define vagrant::plugin($plugin_name = $title, $user = $::id) {
+define vagrant::plugin(
+  $plugin_name    = $title,
+  $user           = $::id
+  $plugin_version = undef,
+) {
   include vagrant::params
 
+  if $plugin_version == undef {
+    $plugin_command = "${vagrant::params::binary} plugin install ${plugin_name}"
+    $plugin_unless = "${vagrant::params::binary} plugin list | ${vagrant::params::grep} \"^${plugin_name}\s\""
+  } else {
+    $plugin_command = "${vagrant::params::binary} plugin install ${plugin_name} --plugin-version ${plugin_version}"
+    $plugin_unless = "${vagrant::params::binary} plugin list | ${vagrant::params::grep} \"^${plugin_name}\s(${plugin_version})\""
+  }
+
   vagrant::command { "${vagrant::params::binary} plugin install ${plugin_name}":
-    user => $user
+    unless => $plugin_unless,
+    user   => $user,
   }
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -13,8 +13,8 @@
 #
 define vagrant::plugin(
   $plugin_name    = $title,
-  $user           = $::id
-  $plugin_version = undef,
+  $user           = $::id,
+  $plugin_version = undef
 ) {
   include vagrant::params
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -26,8 +26,9 @@ define vagrant::plugin(
     $plugin_unless = "${vagrant::params::binary} plugin list | ${vagrant::params::grep} \"^${plugin_name}\s(${plugin_version})\""
   }
 
-  vagrant::command { "${vagrant::params::binary} plugin install ${plugin_name}":
-    unless => $plugin_unless,
-    user   => $user,
+  vagrant::command { "Install vagrant plugin ${plugin_name} for user ${user}":
+    command => $plugin_command,
+    unless  => $plugin_unless,
+    user    => $user,
   }
 }


### PR DESCRIPTION
Vagrant provides functionality to install plugin with specified version. It's sometimes useful to install just some version of plugin, not latest.
