### PR TITLE
Preserve Vagrant DEB file across reboots.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,7 +94,7 @@ class vagrant($version = get_latest_vagrant_version()) {
         }
       }
 
-      $vagrant_source = "${::ostempdir}/${vagrant_filename}"
+      $vagrant_source = "/var/tmp/${vagrant_filename}"
 
       exec { 'vagrant-download':
         command => "/usr/bin/wget -O ${vagrant_source} ${base_url}/${vagrant_filename}",


### PR DESCRIPTION
The contents of `/tmp` get removed on system reboot (see http://www.pathname.com/fhs/pub/fhs-2.3.html#VARTMPTEMPORARYFILESPRESERVEDBETWEE). This causes a download of the appropriate DEB package everytime the `package` resource is evaluated after a system reboot.

By using `/var/tmp` instead, we avoid uneeded downloads of the DEB package for a longer time (i.e., until `/var/tmp` gets cleaned up).
